### PR TITLE
Use internal hassio token to authenticate MMM-HASS

### DIFF
--- a/magic_mirror/config.js
+++ b/magic_mirror/config.js
@@ -145,6 +145,7 @@ var config = {
                         host: "hassio/homeassistant", // Special docker ha api proxy
                         port: "",
                         https: false,
+                        hassiotoken: true,
                         devices: [
                         { deviceLabel: "Exterior",
                                 deviceReadings: [

--- a/magic_mirror/config.json
+++ b/magic_mirror/config.json
@@ -42,7 +42,7 @@
       },
       {
         "name": "MMM-HASS",
-        "git": "https://github.com/sytone/MMM-HASS.git",
+        "git": "https://github.com/aserramonner/MMM-HASS.git",
         "cmd": ""
       }
     ]


### PR DESCRIPTION
I added a feature in upstream MMM-HASS to use the hassiotoken that hass.io add-ons have access to to authenticate MMM-HASS to the internal API. This PR makes MMM-HASS work out-of-the-box (assuming sensor names match), instead of users needing to configure an api password.