### PR TITLE
Update config.js - bind address doesn't work

### DIFF
--- a/magic_mirror/config.js
+++ b/magic_mirror/config.js
@@ -12,7 +12,7 @@
  */
 
 var config = {
-    address: "", // Empty as running in a docker container.
+    address: "0.0.0.0", // Empty will only run on 127.0.0.1 - share on all addresses inside docker container.
     port: 8080, // Update port in HASS.IO configuration and not here.
     ipWhitelist: [], // Empty as in docker container, ACL from the host.
 


### PR DESCRIPTION
If left blank, bind address only binds to 127.0.0.1 inside docker container - we need it to bind to the external address.